### PR TITLE
Add mac/linux startup scripts

### DIFF
--- a/run_client.sh
+++ b/run_client.sh
@@ -1,0 +1,27 @@
+TICEXE=./tic80-macos-arm64/tic80
+CLIENT_EXE=./target/release/ticws-client
+SHOWDOWN_FILE="client_showdown_$1_$2.dat"
+
+if [ -z "$1" ] || [ -z "$2" ] ; then
+    echo "Usage: $0 <room> <handle>"
+    exit 1
+fi
+
+if [ ! -x $TICEXE ]; then
+    TIC_CHECK=`command -v tic80`
+    if [ -z "$TIC_CHECK" ]; then
+        echo "$TICEXE not found and tic80 not in path"
+        exit 1
+    else
+        TICEXE="tic80"
+    fi
+fi
+
+if [ ! -x "$CLIENT_EXE" ]; then
+    echo "$CLIENT_EXE not found / not executable"
+    exit 1
+fi
+
+touch $SHOWDOWN_FILE
+$TICEXE --fft --skip "--codeexport=$SHOWDOWN_FILE" --delay=5 &
+$CLIENT_EXE "$1" "$2" "$SHOWDOWN_FILE"

--- a/run_server.sh
+++ b/run_server.sh
@@ -1,0 +1,27 @@
+TICEXE=./tic80-macos-arm64/tic80
+SERVER_EXE=./target/release/ticws-server
+SHOWDOWN_FILE="server_showdown_$1_$2.dat"
+
+if [ -z "$1" ] || [ -z "$2" ] ; then
+    echo "Usage: $0 <room> <handle>"
+    exit 1
+fi
+
+if [ ! -x $TICEXE ]; then
+    TIC_CHECK=`command -v tic80`
+    if [ -z "$TIC_CHECK" ]; then
+        echo "$TICEXE not found and tic80 not in path"
+        exit 1
+    else
+        TICEXE="tic80"
+    fi
+fi
+
+
+if [ ! -x "$SERVER_EXE" ]; then
+    echo "$SERVER_EXE not found / not executable"
+    exit 1
+fi
+
+$TICEXE --skip "--codeimport=$SHOWDOWN_FILE" --fft --delay=5 &
+$SERVER_EXE "$1" "$2" "$SHOWDOWN_FILE"


### PR DESCRIPTION
Add shell scripts to start client/server on mac and linux. Defaults to whichever tic80 is in $PATH, unless there's a copy in ./tic80-macos-arm64/ in which case that's used